### PR TITLE
Support for MariaDB and Oracle added

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,32 @@ may not be really feasible.
 ## Supported Databases
 
 -   MySQL
+-   MariaDB
 -   PostgreSQL
+-   Oracle
 
-Support for other databases may be conveniently added by extending `SessionLockService`.  For Oracle one may look at:
+Support for other databases may be conveniently added by extending `SessionLockService`.
 
--   [DBMS_LOCK](https://docs.oracle.com/en/database/oracle/oracle-database/12.2/arpls/DBMS_LOCK.html) (Database PL/SQL Packages and Types Reference)
--   [Using Oracle Lock Management Services (User Locks)](https://www.oracle.com/pls/topic/lookup?ctx=en/database/oracle/oracle-database/12.2/arpls&id=ADFNS-GUID-57365E45-5F85-471B-81D9-F52EA16F1E85)
+### Oracle
+
+The Oracle implementation relies on [`DBMS_LOCK`](https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_LOCK.html).
+The user that executes liquibase must have `EXECUTE` privilege on `DBMS_LOCK`.
+
+```sql
+grant execute on SYS.DBMS_LOCK to <user>;  
+```
+
+Oracle does not provide a way to retrieve lock details (e.g. who owns a lock) without elevated privileges.
+You can use the following query to get lock details:
+
+```sql
+select locks_allocated.*, locks.*
+from dba_locks locks, sys.dbms_lock_allocated locks_allocated
+where locks.lock_id1 = locks_allocated.lockid
+and locks_allocated.name = 'lockname';
+```
+
+However, it's possible to get some information about the current session from `SYS_CONTEXT`, so that's what gets returned by the `DatabaseChangeLogLock` object.
 
 ## Usage
 To use the new lockservice, simply add a dependency to the library. Because the priority is higher
@@ -32,11 +52,11 @@ than the StandardLockService, it will automatically be used (provided the databa
 <dependency>
     <groupId>com.github.blagerweij</groupId>
     <artifactId>liquibase-sessionlock</artifactId>
-    <version>1.2.5</version>
+    <version>1.4.0</version>
 </dependency>
 ```
 ### Gradle
-`implementation 'com.github.blagerweij:liquibase-sessionlock:1.2.5'`
+`implementation 'com.github.blagerweij:liquibase-sessionlock:1.4.0'`
 
 ## Disclaimer
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,13 +42,17 @@ dependencies {
             'org.junit.jupiter:junit-jupiter-engine:5.7.0',
     )
     itestImplementation(
-            platform('org.testcontainers:testcontainers-bom:1.15.1'),
+            platform('org.testcontainers:testcontainers-bom:1.15.2'),
             'mysql:mysql-connector-java:8.0.20',
             'org.liquibase:liquibase-core:3.8.9',
             'org.postgresql:postgresql:42.2.14',
+            'org.mariadb.jdbc:mariadb-java-client:2.7.2',
+            'com.oracle.database.jdbc:ojdbc8:21.1.0.0',
             'org.testcontainers:junit-jupiter',
             'org.testcontainers:mysql',
             'org.testcontainers:postgresql',
+            'org.testcontainers:mariadb',
+            'org.testcontainers:oracle-xe',
     )
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.3.1
+version=1.4.0
 systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false
 systemProp.org.gradle.internal.http.connectionTimeout=200000
 systemProp.org.gradle.internal.http.socketTimeout=200000

--- a/src/itest/java/liquibase/ext/MariaDBLiquibaseUpdateTest.java
+++ b/src/itest/java/liquibase/ext/MariaDBLiquibaseUpdateTest.java
@@ -1,22 +1,22 @@
 package liquibase.ext;
 
-import com.github.blagerweij.sessionlock.MySQLLockService;
+import com.github.blagerweij.sessionlock.MariaDBLockService;
 import com.github.blagerweij.sessionlock.SessionLockService;
 
 import org.testcontainers.containers.JdbcDatabaseContainer;
-import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.MariaDBContainer;
 import org.testcontainers.junit.jupiter.Container;
 
-class MySQLLiquibaseUpdateTest extends AbstractLiquibaseUpdateTest {
-  @Container private static final MySQLContainer MY_SQL_CONTAINER = new MySQLContainer("mysql");
+class MariaDBLiquibaseUpdateTest extends AbstractLiquibaseUpdateTest {
+  @Container private static final MariaDBContainer MARIA_DB_CONTAINER = new MariaDBContainer("mariadb");
 
   @Override
   protected Class<? extends SessionLockService> getExpectedLockServiceClass() {
-    return MySQLLockService.class;
+    return MariaDBLockService.class;
   }
 
   @Override
   protected JdbcDatabaseContainer getDatabaseContainer() {
-    return MY_SQL_CONTAINER;
+    return MARIA_DB_CONTAINER;
   }
 }

--- a/src/itest/java/liquibase/ext/OracleXELiquibaseUpdateTest.java
+++ b/src/itest/java/liquibase/ext/OracleXELiquibaseUpdateTest.java
@@ -1,0 +1,22 @@
+package liquibase.ext;
+
+import com.github.blagerweij.sessionlock.OracleLockService;
+import com.github.blagerweij.sessionlock.SessionLockService;
+
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.OracleContainer;
+import org.testcontainers.junit.jupiter.Container;
+
+class OracleXELiquibaseUpdateTest extends AbstractLiquibaseUpdateTest {
+  @Container private static final OracleContainer ORACLE_DB_CONTAINER = new OracleContainer("oracleinanutshell/oracle-xe-11g");
+
+  @Override
+  protected Class<? extends SessionLockService> getExpectedLockServiceClass() {
+    return OracleLockService.class;
+  }
+
+  @Override
+  protected JdbcDatabaseContainer getDatabaseContainer() {
+    return ORACLE_DB_CONTAINER;
+  }
+}

--- a/src/itest/java/liquibase/ext/PGLiquibaseUpdateTest.java
+++ b/src/itest/java/liquibase/ext/PGLiquibaseUpdateTest.java
@@ -1,13 +1,20 @@
 package liquibase.ext;
 
+import com.github.blagerweij.sessionlock.PGLockService;
+import com.github.blagerweij.sessionlock.SessionLockService;
+
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 
 class PGLiquibaseUpdateTest extends AbstractLiquibaseUpdateTest {
   @Container
-  private static final PostgreSQLContainer POSTGRES_SQL_CONTAINER =
-      new PostgreSQLContainer("postgres");
+  private static final PostgreSQLContainer POSTGRES_SQL_CONTAINER = new PostgreSQLContainer("postgres");
+
+  @Override
+  protected Class<? extends SessionLockService> getExpectedLockServiceClass() {
+    return PGLockService.class;
+  }
 
   @Override
   protected JdbcDatabaseContainer getDatabaseContainer() {

--- a/src/itest/resources/liquibase/ext/changelog.xml
+++ b/src/itest/resources/liquibase/ext/changelog.xml
@@ -14,7 +14,13 @@
                             http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
 
     <changeSet id="1" author="john" runInTransaction="false">
+        <sql dbms="mariadb">SELECT SLEEP(5)</sql>
         <sql dbms="mysql">SELECT SLEEP(5)</sql>
+        <sql dbms="oracle" splitStatements="false">
+            BEGIN
+              DBMS_LOCK.SLEEP(5);
+            END;
+        </sql>
         <sql dbms="postgresql">SELECT pg_sleep(5)</sql>
         <rollback><!-- Do nothing --></rollback>
     </changeSet>

--- a/src/main/java/com/github/blagerweij/sessionlock/MariaDBLockService.java
+++ b/src/main/java/com/github/blagerweij/sessionlock/MariaDBLockService.java
@@ -1,0 +1,64 @@
+/*
+ * This module, both source code and documentation,
+ * is in the Public Domain, and comes with NO WARRANTY.
+ */
+package com.github.blagerweij.sessionlock;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import liquibase.database.Database;
+import liquibase.database.core.MariaDBDatabase;
+import liquibase.exception.LockException;
+import liquibase.lockservice.DatabaseChangeLogLock;
+
+/**
+ * Employs MariaDB user-level (a.k.a.&#x20;application-level or advisory) locks.
+ *
+ * See {@link MySQLLockService} for more details.
+ *
+ * @see "<a href='https://mariadb.com/kb/en/miscellaneous-functions/'>Locking
+ *     Functions</a> (MariaDB Reference Manual)"
+ */
+public class MariaDBLockService extends MySQLLockService {
+
+  @Override
+  public boolean supports(Database database) {
+    return (database instanceof MariaDBDatabase);
+  }
+
+  /**
+   * @see "<a
+   *     href='https://mariadb.com/kb/en/get_lock/'>
+   *     <code>GET_LOCK</code></a> (MariaDB Documentation)"
+   */
+  @Override
+  protected boolean acquireLock(Connection con) throws SQLException, LockException {
+    return super.acquireLock(con);
+  }
+
+  /**
+   * @see "<a
+   *     href='https://mariadb.com/kb/en/release_lock/'>
+   *     <code>RELEASE_LOCK</code></a> (MariaDB Documentation)"
+   */
+  @Override
+  protected void releaseLock(Connection con) throws SQLException, LockException {
+    super.releaseLock(con);
+  }
+
+  /**
+   * Obtains information about the database changelog lock.
+   *
+   * @see "<a
+   *     href='https://mariadb.com/kb/en/is_used_lock/'>
+   *     <code>IS_USED_LOCK</code></a> (MariaDB Documentation)"
+   * @see "<a href='https://mariadb.com/kb/en/information-schema-processlist-table/'>The
+   *     INFORMATION_SCHEMA PROCESSLIST Table</a> (MariaDB Documentation)"
+   */
+  @Override
+  protected DatabaseChangeLogLock usedLock(Connection con) throws SQLException, LockException {
+    return super.usedLock(con);
+  }
+
+}

--- a/src/main/java/com/github/blagerweij/sessionlock/OracleLockService.java
+++ b/src/main/java/com/github/blagerweij/sessionlock/OracleLockService.java
@@ -1,0 +1,176 @@
+/*
+ * This module, both source code and documentation,
+ * is in the Public Domain, and comes with NO WARRANTY.
+ */
+package com.github.blagerweij.sessionlock;
+
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Date;
+import java.util.Locale;
+
+import liquibase.database.Database;
+import liquibase.database.core.OracleDatabase;
+import liquibase.exception.LockException;
+import liquibase.lockservice.DatabaseChangeLogLock;
+
+/**
+ * Employs Oracle user-level (a.k.a.&#x20;application-level or advisory) locks.
+ *
+ * See {@link MySQLLockService} for a very similar implementation.
+ *
+ * @see "<a href='https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_LOCK.html'>
+ *   <code>DBMS_LOCK</code> Package</a> (Oracle PL/SQL Reference Manual)"
+ */
+public class OracleLockService extends SessionLockService {
+
+  static final String SQL_ALLOCATE_LOCK = "{ call dbms_lock.allocate_unique(?, ?) }";
+  static final String SQL_GET_LOCK = "{ ? = call dbms_lock.request(?, ?, ?) }";
+  static final String SQL_RELEASE_LOCK = "{ ? = call dbms_lock.release(?) }";
+  static final String SQL_LOCK_INFO =
+      "SELECT SYS_CONTEXT ('USERENV', 'SESSIONID') SESSIONID,\n" +
+          "   SYS_CONTEXT ('USERENV', 'CURRENT_USER') CURRENT_USER,\n" +
+          "   SYS_CONTEXT ('USERENV', 'CURRENT_SCHEMA') CURRENT_SCHEMA,\n" +
+          "   SYS_CONTEXT ('USERENV', 'INSTANCE_NAME') INSTANCE_NAME,\n" +
+          "   SYS_CONTEXT ('USERENV', 'HOST') HOST,\n" +
+          "   SYS_CONTEXT ('USERENV', 'OS_USER') OS_USER\n" +
+          " FROM DUAL";
+
+  private static final String DBMS_LOCK_REQUEST_FOR_LOCK = "dbms_lock.request() for lock ";
+  private static final String DBMS_LOCK_RELEASE_FOR_LOCK = "dbms_lock.release() for lock ";
+
+  @Override
+  public boolean supports(Database database) {
+    return (database instanceof OracleDatabase);
+  }
+
+  private String getChangeLogLockName() {
+    return (database.getDefaultSchemaName() + "." + database.getDatabaseChangeLogLockTableName())
+        .toUpperCase(Locale.ROOT);
+  }
+
+  /**
+   * @see "<a href='https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_LOCK.html#GUID-73F03FA6-04B3-4341-AB4F-8BECCF898D13'>
+   *     <code>DBMS_LOCK.ALLOCATE_UNIQUE</code> Procedure</a> (Oracle PL/SQL Reference Manual)"
+   */
+  private String allocateLock(Connection con) throws SQLException {
+    // Allocate lock
+    try (CallableStatement stmt = con.prepareCall(SQL_ALLOCATE_LOCK)) {
+      stmt.setString(1, getChangeLogLockName());
+      stmt.registerOutParameter(2, Types.VARCHAR);
+      stmt.executeQuery();
+
+      return stmt.getString(2);
+
+    }
+  }
+
+  /**
+   * @see "<a href='https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_LOCK.html#GUID-CC3AEC00-CBFF-45DD-99C3-C7A312C0213E'>
+   *     <code>DBMS_LOCK.REQUEST</code> Procedure</a> (Oracle PL/SQL Reference Manual)"
+   */
+  @Override
+  protected boolean acquireLock(Connection con) throws SQLException, LockException {
+    String lockHandle = allocateLock(con);
+    try (CallableStatement stmt = con.prepareCall(SQL_GET_LOCK)) {
+      stmt.registerOutParameter(1, Types.INTEGER);
+      stmt.setString(2, lockHandle);
+      stmt.setInt(3, 6); // X_MODE -> Exclusive lock mode
+      final int timeoutSeconds = 5;
+      stmt.setInt(4, timeoutSeconds);
+      stmt.executeQuery();
+
+      int rc = stmt.getInt(1);
+      if (rc == 1) { // Timeout - lock held by other session
+        return false;
+      } else if (rc == 2) {
+        throw new LockException(DBMS_LOCK_REQUEST_FOR_LOCK + getChangeLogLockName() + " returned deadlock");
+      } else if (rc == 3) {
+        throw new LockException(DBMS_LOCK_REQUEST_FOR_LOCK + getChangeLogLockName() + " returned parameter error");
+      } else if (rc == 4) {
+        throw new LockException(DBMS_LOCK_REQUEST_FOR_LOCK + getChangeLogLockName() + " returned already own lock specified by lockHandle");
+      } else if (rc == 5) {
+        throw new LockException(DBMS_LOCK_REQUEST_FOR_LOCK + getChangeLogLockName() + " returned illegal lock handle");
+      }
+      return true;
+    }
+  }
+
+  /**
+   * @see "<a href='https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_LOCK.html#GUID-1007B402-15D3-4447-9FF3-219DF113A47B'>
+   *     <code>DBMS_LOCK.RELEASE</code> Procedure</a> (Oracle PL/SQL Reference Manual)"
+   */
+  @Override
+  protected void releaseLock(Connection con) throws SQLException, LockException {
+    String lockHandle = allocateLock(con);
+    try (CallableStatement stmt = con.prepareCall(SQL_RELEASE_LOCK)) {
+      stmt.registerOutParameter(1, Types.INTEGER);
+      stmt.setString(2, lockHandle);
+      stmt.executeQuery();
+
+      int rc = stmt.getInt(1);
+      if (rc == 3) {
+        throw new LockException(DBMS_LOCK_RELEASE_FOR_LOCK + getChangeLogLockName() + " returned parameter error");
+      } else if (rc == 4) {
+        throw new LockException(DBMS_LOCK_RELEASE_FOR_LOCK + getChangeLogLockName() + " returned do not own lock specified by lockHandle");
+      } else if (rc == 5) {
+        throw new LockException(DBMS_LOCK_RELEASE_FOR_LOCK + getChangeLogLockName() + " returned illegal lock handle");
+      }
+    }
+  }
+
+  /**
+   * Obtains information about the database changelog lock. <br/>
+   * Oracle does not provide a way to retrieve lock details (e.g. who owns a lock) without elevated privileges.
+   * However, it's possible to get some information about the current session, so that's what gets returned by this method.<br/>
+   *
+   * You can use the following query to get lock details:
+   * <pre><code>
+   * SELECT LOCKS_ALLOCATED.*, LOCKS.*
+   * FROM DBA_LOCKS LOCKS, SYS.DBMS_LOCK_ALLOCATED LOCKS_ALLOCATED
+   * WHERE LOCKS.LOCK_ID1 = LOCKS_ALLOCATED.LOCKID
+   * AND LOCKS_ALLOCATED.NAME = 'lockName';
+   * </code></pre>
+   *
+   * @see "<a href='https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/SYS_CONTEXT.html'>
+   *     <code>SYS_CONTEXT</code></a> (Oracle PL/SQL Reference Manual)"
+   * @see "<a href='https://docs.oracle.com/en/database/oracle/oracle-database/19/refrn/DBMS_LOCK_ALLOCATED.html'>The
+   *     DBMS_LOCK_ALLOCATED Table</a> (Oracle PL/SQL Reference Manual)"
+   * @see "<a href='https://docs.oracle.com/en/database/oracle/oracle-database/19/refrn/DBA_LOCK.html'>The
+   *     DBA_LOCK View</a> (Oracle PL/SQL Reference Manual)"
+   */
+  @Override
+  protected DatabaseChangeLogLock usedLock(Connection con) throws SQLException {
+    String lockHandle = allocateLock(con);
+    int lockId = 1;
+    // lock handles are integers between 1073741824 and 1999999999 but they are returned as longer value here
+    if (lockHandle.length() >= 10) {
+      try {
+        lockId = Integer.parseInt(lockHandle.substring(0, 10));
+      } catch (NumberFormatException e) {
+        getLog(getClass()).warning("could not parse lock handle " + lockHandle, e);
+      }
+    }
+    try (PreparedStatement stmt = con.prepareStatement(SQL_LOCK_INFO)) {
+      try (ResultSet rs = stmt.executeQuery()) {
+        if (!rs.next()) {
+          return null;
+        }
+        return new DatabaseChangeLogLock(lockId, new Date(), lockedBy(rs));
+      }
+    }
+  }
+
+  private String lockedBy(ResultSet rs) throws SQLException {
+    String sessionId = rs.getString("SESSIONID");
+    String currentUser = rs.getString("CURRENT_USER");
+    String instanceName = rs.getString("INSTANCE_NAME");
+    String host = rs.getString("HOST");
+    String osUser = rs.getString("OS_USER");
+    return String.format("(session_id=%s)(current_user=%s)(instance_name=%s)(os_user=%s)(host=%s)", sessionId, currentUser, instanceName, osUser, host);
+  }
+}

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,1 @@
+Liquibase-Package: com.github.blagerweij.sessionlock

--- a/src/main/resources/META-INF/services/liquibase.lockservice.LockService
+++ b/src/main/resources/META-INF/services/liquibase.lockservice.LockService
@@ -1,2 +1,4 @@
+com.github.blagerweij.sessionlock.MariaDBLockService
 com.github.blagerweij.sessionlock.MySQLLockService
+com.github.blagerweij.sessionlock.OracleLockService
 com.github.blagerweij.sessionlock.PGLockService

--- a/src/test/java/com/github/blagerweij/sessionlock/MariaDBLockServiceTest.java
+++ b/src/test/java/com/github/blagerweij/sessionlock/MariaDBLockServiceTest.java
@@ -1,0 +1,159 @@
+/*
+ * This module, both source code and documentation,
+ * is in the Public Domain, and comes with NO WARRANTY.
+ */
+package com.github.blagerweij.sessionlock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import liquibase.database.core.MariaDBDatabase;
+import liquibase.database.core.MySQLDatabase;
+import liquibase.database.core.OracleDatabase;
+import liquibase.database.core.PostgresDatabase;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.LockException;
+import liquibase.lockservice.DatabaseChangeLogLock;
+
+public class MariaDBLockServiceTest {
+
+  private MariaDBLockService lockService;
+
+  private Connection dbCon;
+
+  @BeforeEach
+  public void setUp() {
+    dbCon = mock(Connection.class);
+
+    MariaDBDatabase database = new MariaDBDatabase();
+    database.setDefaultCatalogName("test_schema");
+    database = spy(database);
+    when(database.getConnection()).thenReturn(new JdbcConnection(dbCon));
+
+    lockService = new MariaDBLockService();
+    lockService.setDatabase(database);
+  }
+
+  @Test
+  public void supports() {
+    assertThat(lockService.supports(new MariaDBDatabase())).isTrue();
+  }
+
+  @Test
+  public void supportsNot() {
+    assertThat(lockService.supports(new PostgresDatabase())).isFalse();
+    assertThat(lockService.supports(new MySQLDatabase())).isFalse();
+    assertThat(lockService.supports(new OracleDatabase())).isFalse();
+  }
+
+  @Test
+  @SuppressWarnings("resource")
+  public void acquireSuccess() throws Exception {
+    PreparedStatement stmt = mock(PreparedStatement.class);
+    ResultSet rs = intResult(1);
+    when(stmt.executeQuery()).thenReturn(rs);
+    when(dbCon.prepareStatement(MariaDBLockService.SQL_GET_LOCK)).thenReturn(stmt);
+
+    assertThat(lockService.acquireLock()).isTrue();
+    verify(stmt).setString(1, "TEST_SCHEMA.DATABASECHANGELOGLOCK");
+  }
+
+  @Test
+  @SuppressWarnings("resource")
+  public void acquireUnsuccessful() throws Exception {
+    PreparedStatement stmt = mock(PreparedStatement.class);
+    ResultSet rs = intResult(0);
+    when(stmt.executeQuery()).thenReturn(rs);
+    when(dbCon.prepareStatement(MariaDBLockService.SQL_GET_LOCK)).thenReturn(stmt);
+
+    assertThat(lockService.acquireLock()).isFalse();
+  }
+
+  @Test
+  @SuppressWarnings("resource")
+  public void acquireFailure() throws Exception {
+    PreparedStatement stmt = mock(PreparedStatement.class);
+    ResultSet rs = mock(ResultSet.class);
+    when(stmt.executeQuery()).thenReturn(rs);
+    when(dbCon.prepareStatement(MariaDBLockService.SQL_GET_LOCK)).thenReturn(stmt);
+
+    assertThatThrownBy(() -> lockService.acquireLock()).isInstanceOf(LockException.class);
+  }
+
+  @Test
+  @SuppressWarnings("resource")
+  public void releaseSuccess() throws Exception {
+    PreparedStatement stmt = mock(PreparedStatement.class);
+    ResultSet rs = intResult(1);
+    when(stmt.executeQuery()).thenReturn(rs);
+    when(dbCon.prepareStatement(MariaDBLockService.SQL_RELEASE_LOCK)).thenReturn(stmt);
+
+    lockService.releaseLock();
+    verify(stmt).setString(1, "TEST_SCHEMA.DATABASECHANGELOGLOCK");
+  }
+
+  @Test
+  @SuppressWarnings("resource")
+  public void releaseFailure() throws Exception {
+    PreparedStatement stmt = mock(PreparedStatement.class);
+    ResultSet rs = intResult(0);
+    when(stmt.executeQuery()).thenReturn(rs);
+    when(dbCon.prepareStatement(MariaDBLockService.SQL_RELEASE_LOCK)).thenReturn(stmt);
+
+    assertThatThrownBy(() -> lockService.releaseLock()).isInstanceOf(LockException.class);
+  }
+
+  @Test
+  @SuppressWarnings("resource")
+  public void usedLockInfo() throws Exception {
+    ResultSet infoResult = mock(ResultSet.class);
+    when(infoResult.next()).thenReturn(true).thenReturn(false);
+    when(infoResult.getObject("PROCESSLIST_ID")).thenReturn(123);
+    when(infoResult.getString("HOST")).thenReturn("192.168.254.254:12345");
+    when(infoResult.getString("STATE")).thenReturn("testing");
+    when(infoResult.getInt("TIME")).thenReturn(15);
+
+    PreparedStatement stmt = mock(PreparedStatement.class);
+    when(stmt.executeQuery()).thenReturn(infoResult);
+    when(dbCon.prepareStatement(MariaDBLockService.SQL_LOCK_INFO)).thenReturn(stmt);
+
+    DatabaseChangeLogLock[] lockList = lockService.listLocks();
+    verify(stmt).setString(1, "TEST_SCHEMA.DATABASECHANGELOGLOCK");
+    assertThat(lockList).hasSize(1);
+    assertThat(lockList[0]).isNotNull();
+    assertThat(lockList[0].getLockedBy()).isEqualTo("192.168.254.254 (testing)");
+  }
+
+  @Test
+  @SuppressWarnings("resource")
+  public void noLockInfo() throws Exception {
+    ResultSet infoResult = mock(ResultSet.class);
+    when(infoResult.next()).thenReturn(false);
+    PreparedStatement stmt = mock(PreparedStatement.class);
+    when(stmt.executeQuery()).thenReturn(infoResult);
+    when(dbCon.prepareStatement(MariaDBLockService.SQL_LOCK_INFO)).thenReturn(stmt);
+
+    DatabaseChangeLogLock[] lockList = lockService.listLocks();
+    assertThat(lockList).isEmpty();
+  }
+
+  // Single row / single column
+  private static ResultSet intResult(int value) throws SQLException {
+    ResultSet rs = mock(ResultSet.class);
+    when(rs.next()).thenReturn(true).thenReturn(false);
+    when(rs.getObject(1)).thenReturn(value);
+    return rs;
+  }
+}

--- a/src/test/java/com/github/blagerweij/sessionlock/OracleLockServiceTest.java
+++ b/src/test/java/com/github/blagerweij/sessionlock/OracleLockServiceTest.java
@@ -1,0 +1,200 @@
+/*
+ * This module, both source code and documentation,
+ * is in the Public Domain, and comes with NO WARRANTY.
+ */
+package com.github.blagerweij.sessionlock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import liquibase.database.core.MariaDBDatabase;
+import liquibase.database.core.MySQLDatabase;
+import liquibase.database.core.OracleDatabase;
+import liquibase.database.core.PostgresDatabase;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.LockException;
+import liquibase.lockservice.DatabaseChangeLogLock;
+
+public class OracleLockServiceTest {
+
+  public static final String LOCK_ID = "1073741824";
+
+  private OracleLockService lockService;
+
+  private Connection dbCon;
+
+  @BeforeEach
+  public void setUp() {
+    dbCon = mock(Connection.class);
+
+    OracleDatabase database = new OracleDatabase();
+    database.setDefaultCatalogName("test_schema");
+    database = spy(database);
+    when(database.getConnection()).thenReturn(new JdbcConnection(dbCon));
+
+    lockService = new OracleLockService();
+    lockService.setDatabase(database);
+  }
+
+  @Test
+  public void supports() {
+    assertThat(lockService.supports(new OracleDatabase())).isTrue();
+  }
+
+  @Test
+  public void supportsNot() {
+    assertThat(lockService.supports(new PostgresDatabase())).isFalse();
+    assertThat(lockService.supports(new MySQLDatabase())).isFalse();
+    assertThat(lockService.supports(new MariaDBDatabase())).isFalse();
+  }
+
+  @Test
+  @SuppressWarnings("resource")
+  public void acquireSuccess() throws Exception {
+    mockAllocateLock(dbCon);
+
+    CallableStatement stmt = mock(CallableStatement.class);
+    when(stmt.getInt(1)).thenReturn(0);
+    when(dbCon.prepareCall(OracleLockService.SQL_GET_LOCK)).thenReturn(stmt);
+
+    assertThat(lockService.acquireLock()).isTrue();
+    InOrder inOrder = inOrder(stmt);
+    inOrder.verify(stmt).registerOutParameter(1, Types.INTEGER);
+    inOrder.verify(stmt).setString(2,LOCK_ID);
+    inOrder.verify(stmt).setInt(3,6);
+    inOrder.verify(stmt).setInt(4,5);
+    inOrder.verify(stmt).executeQuery();
+    inOrder.verify(stmt).getInt(1);
+    inOrder.verify(stmt).close();
+  }
+
+  @Test
+  @SuppressWarnings("resource")
+  public void acquireUnsuccessful() throws Exception {
+    mockAllocateLock(dbCon);
+
+    CallableStatement stmt = mock(CallableStatement.class);
+    when(stmt.getInt(1)).thenReturn(1);
+    when(dbCon.prepareCall(OracleLockService.SQL_GET_LOCK)).thenReturn(stmt);
+
+    assertThat(lockService.acquireLock()).isFalse();
+  }
+
+  @Test
+  @SuppressWarnings("resource")
+  public void acquireFailure() throws Exception {
+    mockAllocateLock(dbCon);
+
+    CallableStatement stmt = mock(CallableStatement.class);
+    when(stmt.getInt(1)).thenReturn(2);
+    when(dbCon.prepareCall(OracleLockService.SQL_GET_LOCK)).thenReturn(stmt);
+
+    assertThatThrownBy(() -> lockService.acquireLock()).isInstanceOf(LockException.class);
+  }
+
+  @Test
+  @SuppressWarnings("resource")
+  public void releaseSuccess() throws Exception {
+    mockAllocateLock(dbCon);
+
+    CallableStatement stmt = mock(CallableStatement.class);
+    when(stmt.getInt(1)).thenReturn(1);
+    when(dbCon.prepareCall(OracleLockService.SQL_RELEASE_LOCK)).thenReturn(stmt);
+
+    lockService.releaseLock();
+    InOrder inOrder = inOrder(stmt);
+    inOrder.verify(stmt).registerOutParameter(1, Types.INTEGER);
+    inOrder.verify(stmt).setString(2,LOCK_ID);
+    inOrder.verify(stmt).executeQuery();
+    inOrder.verify(stmt).getInt(1);
+    inOrder.verify(stmt).close();
+  }
+
+  @Test
+  @SuppressWarnings("resource")
+  public void releaseFailure() throws Exception {
+    mockAllocateLock(dbCon);
+
+    CallableStatement stmt = mock(CallableStatement.class);
+    when(stmt.getInt(1)).thenReturn(3);
+    when(dbCon.prepareCall(OracleLockService.SQL_RELEASE_LOCK)).thenReturn(stmt);
+
+    assertThatThrownBy(() -> lockService.releaseLock()).isInstanceOf(LockException.class);
+  }
+
+  @Test
+  @SuppressWarnings("resource")
+  public void usedLockInfo() throws Exception {
+    mockAllocateLock(dbCon);
+
+    ResultSet infoResult = mock(ResultSet.class);
+    when(infoResult.next()).thenReturn(true).thenReturn(false);
+    when(infoResult.getString("SESSIONID")).thenReturn("sessionId");
+    when(infoResult.getString("CURRENT_USER")).thenReturn("currentUser");
+    when(infoResult.getString("CURRENT_SCHEMA")).thenReturn("currentSchema");
+    when(infoResult.getString("INSTANCE_NAME")).thenReturn("instanceName");
+    when(infoResult.getString("HOST")).thenReturn("host");
+    when(infoResult.getString("OS_USER")).thenReturn("osUser");
+
+    PreparedStatement stmt = mock(PreparedStatement.class);
+    when(stmt.executeQuery()).thenReturn(infoResult);
+    when(dbCon.prepareStatement(OracleLockService.SQL_LOCK_INFO)).thenReturn(stmt);
+
+    DatabaseChangeLogLock[] lockList = lockService.listLocks();
+    verify(stmt).executeQuery();
+    verify(stmt).close();
+    assertThat(lockList).hasSize(1);
+    assertThat(lockList[0]).isNotNull();
+    assertThat(lockList[0].getId()).isEqualTo(Integer.parseInt(LOCK_ID));
+    assertThat(lockList[0].getLockGranted()).isInSameDayAs(new Date());
+    assertThat(lockList[0].getLockedBy()).isEqualTo("(session_id=sessionId)(current_user=currentUser)(instance_name=instanceName)(os_user=osUser)(host=host)");
+    verifyLockParameters(stmt);
+  }
+
+
+  private void verifyLockParameters(PreparedStatement stmt) throws SQLException {
+    verify(stmt).executeQuery();
+    verify(stmt).close();
+    verifyNoMoreInteractions(stmt);
+  }
+
+  @Test
+  @SuppressWarnings("resource")
+  public void noLockInfo() throws Exception {
+    mockAllocateLock(dbCon);
+
+    ResultSet infoResult = mock(ResultSet.class);
+    when(infoResult.next()).thenReturn(false);
+    PreparedStatement stmt = mock(PreparedStatement.class);
+    when(stmt.executeQuery()).thenReturn(infoResult);
+    when(dbCon.prepareStatement(OracleLockService.SQL_LOCK_INFO)).thenReturn(stmt);
+
+    DatabaseChangeLogLock[] lockList = lockService.listLocks();
+    assertThat(lockList).isEmpty();
+  }
+
+  private void mockAllocateLock(Connection c) throws SQLException {
+    CallableStatement stmtAllocate = mock(CallableStatement.class);
+    when(stmtAllocate.getString(2)).thenReturn(LOCK_ID);
+    when(c.prepareCall(OracleLockService.SQL_ALLOCATE_LOCK)).thenReturn(stmtAllocate);
+  }
+
+}


### PR DESCRIPTION
Hi @blagerweij 

In this PR I have implemented MariaDB and Oracle support for the session lock implementation. I have successfully tested it on some real module already and it seems to work fine. Please let me know if you have any feedback and improvement ideas. Otherwise it would be great if you can merge it.

One thing I noticed and that was puzzling me is that I had to always run `./gradlew clean integrationTest` to get a consistent result during the integration tests. It seems to be an issue with testcontainers or how the tests are run. If you run one-by-one this problem does not appear and it only appears occasionally. It also does not appear in IntelliJ. Anyway, the code works as designed.