### PR TITLE
Throw more human-readable exception in case if default schema is not set

### DIFF
--- a/src/main/java/com/github/blagerweij/sessionlock/PGLockService.java
+++ b/src/main/java/com/github/blagerweij/sessionlock/PGLockService.java
@@ -68,12 +68,16 @@ public class PGLockService extends SessionLockService {
     }
   }
 
-  private int[] getChangeLogLockId() {
+  private int[] getChangeLogLockId() throws LockException {
+    String defaultSchemaName = database.getDefaultSchemaName();
+    if (defaultSchemaName == null) {
+      throw new LockException("Default schema name is not set for current DB user/connection");
+    }
     // Unlike the general Object.hashCode() contract,
     // String.hashCode() should be stable across VM instances and Java versions.
     return new int[] {
       database.getDatabaseChangeLogLockTableName().hashCode(),
-      database.getDefaultSchemaName().hashCode()
+      defaultSchemaName.hashCode()
     };
   }
 


### PR DESCRIPTION
Currently if default schema is not set for a PostgreSQL connection, library throws cryptic NPE without any messages.
We get this in our deployment:
```
Caused by: java.lang.NullPointerException
        at com.github.blagerweij.sessionlock.PGLockService.getChangeLogLockId(PGLockService.java:76) ~[liquibase-sessionlock-1.4.0.jar:?]
        at com.github.blagerweij.sessionlock.PGLockService.acquireLock(PGLockService.java:95) ~[liquibase-sessionlock-1.4.0.jar:?]
        at com.github.blagerweij.sessionlock.SessionLockService.acquireLock(SessionLockService.java:79) ~[liquibase-sessionlock-1.4.0.jar:?]
        at liquibase.lockservice.StandardLockService.waitForLock(StandardLockService.java:212) ~[liquibase-core-4.3.1.jar:?]
        at liquibase.Liquibase.lambda$update$1(Liquibase.java:219) ~[liquibase-core-4.3.1.jar:?]
        at liquibase.Scope.lambda$child$0(Scope.java:160) ~[liquibase-core-4.3.1.jar:?]
        at liquibase.Scope.child(Scope.java:169) ~[liquibase-core-4.3.1.jar:?]
        at liquibase.Scope.child(Scope.java:159) ~[liquibase-core-4.3.1.jar:?]
        at liquibase.Scope.child(Scope.java:138) ~[liquibase-core-4.3.1.jar:?]
        at liquibase.Liquibase.runInScope(Liquibase.java:2322) ~[liquibase-core-4.3.1.jar:?]
        at liquibase.Liquibase.update(Liquibase.java:216) ~[liquibase-core-4.3.1.jar:?]
        at liquibase.Liquibase.update(Liquibase.java:202) ~[liquibase-core-4.3.1.jar:?]
        at liquibase.integration.spring.SpringLiquibase.performUpdate(SpringLiquibase.java:322) ~[liquibase-core-4.3.1.jar:?]
        at liquibase.integration.spring.SpringLiquibase.afterPropertiesSet(SpringLiquibase.java:275) ~[liquibase-core-4.3.1.jar:?]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1845) ~[spring-beans-5.3.4.jar:5.3.4]
```
I propose to use exception with more detailed explanation.