### PR TITLE
Oracle Permission Testing and Java Property Over-ride

### DIFF
--- a/src/main/java/com/github/blagerweij/sessionlock/MySQLLockService.java
+++ b/src/main/java/com/github/blagerweij/sessionlock/MySQLLockService.java
@@ -44,7 +44,7 @@ public class MySQLLockService extends SessionLockService {
 
   @Override
   public boolean supports(Database database) {
-    return (database instanceof MySQLDatabase);
+    return (database instanceof MySQLDatabase) && !isSessionLockingDisabled();
   }
 
   private String getChangeLogLockName() {

--- a/src/main/java/com/github/blagerweij/sessionlock/PGLockService.java
+++ b/src/main/java/com/github/blagerweij/sessionlock/PGLockService.java
@@ -55,7 +55,7 @@ public class PGLockService extends SessionLockService {
 
   @Override
   public boolean supports(Database database) {
-    return (database instanceof PostgresDatabase) && isAtLeastPostgres91(database);
+    return (database instanceof PostgresDatabase) && isAtLeastPostgres91(database) && !isSessionLockingDisabled();
   }
 
   private static boolean isAtLeastPostgres91(Database database) {

--- a/src/main/java/com/github/blagerweij/sessionlock/SessionLockService.java
+++ b/src/main/java/com/github/blagerweij/sessionlock/SessionLockService.java
@@ -52,6 +52,12 @@ public abstract class SessionLockService extends StandardLockService {
     return false;
   }
 
+  public boolean isSessionLockingDisabled() {
+	  boolean sessionLockingDisabled = Boolean.parseBoolean(System.getProperty("liquibase.sessionlock.disable"));
+	  if (sessionLockingDisabled) getLog(getClass()).info("Session locking has been explicitly disabled with liquibase.sessionlock.disable");
+	  return sessionLockingDisabled;
+  }
+  
   /**
    * This implementation is a <i>no-op</i>. Suppresses creating the {@code DATABASECHANGELOGLOCK}
    * table by the {@code StandardLockService} implementation.


### PR DESCRIPTION
- Test Oracle has permissions before telling Liquibase that the locking
mechanism is supported.

- Disable Locking with liquibase.sessionlock.disable=true