### PR TITLE
Use Oracle gv$ views

### DIFF
--- a/src/main/java/com/github/blagerweij/sessionlock/OracleLockService.java
+++ b/src/main/java/com/github/blagerweij/sessionlock/OracleLockService.java
@@ -32,7 +32,7 @@ public class OracleLockService extends SessionLockService {
   static final String SQL_RELEASE_LOCK = "{ ? = call dbms_lock.release(?) }";
   static final String SQL_LOCK_INFO =
       "select l.sid, current_timestamp - numToDSInterval(l.ctime,'second'), s.USERNAME, s.OSUSER,"
-          + " s.MACHINE from v$lock l join v$session s on l.sid = s.SID where l.type = 'UL'   and"
+          + " s.MACHINE from gv$lock l join gv$session s on l.sid = s.SID where l.type = 'UL'   and"
           + " l.id1 = ?";
 
   @Override


### PR DESCRIPTION
The use of v$lock and v$session can potentially lead to errors if used
by a multi node Oracle RAC environment.