### PR TITLE
Change how getChangeLogLockName() for Oracle work

### DIFF
--- a/src/main/java/com/github/blagerweij/sessionlock/OracleLockService.java
+++ b/src/main/java/com/github/blagerweij/sessionlock/OracleLockService.java
@@ -41,7 +41,7 @@ public class OracleLockService extends SessionLockService {
   }
 
   private String getChangeLogLockName() {
-    return (database.getDefaultSchemaName() + "." + database.getDatabaseChangeLogLockTableName())
+    return (database.getLiquibaseSchemaName() + "." + database.getDatabaseChangeLogLockTableName())
         .toUpperCase(Locale.ROOT);
   }
 


### PR DESCRIPTION
database.getDefaultSchemaName() would return the user logged on to the
database. If the same user is used for several parallell migrations on
different Liquibase schemas unneccessary locks would be introduced.

database.getLiquibaseSchemaName() is more correct as it would set the
lock handle as Liquibases original changelogLock table.