### PR TITLE
Skip releasing lock when hasChangeLogLock indicates that no lock is set

### DIFF
--- a/src/test/java/com/github/blagerweij/sessionlock/MySQLLockServiceTest.java
+++ b/src/test/java/com/github/blagerweij/sessionlock/MySQLLockServiceTest.java
@@ -89,6 +89,8 @@ public class MySQLLockServiceTest {
   @Test
   @SuppressWarnings("resource")
   public void releaseSuccess() throws Exception {
+    lockService.hasChangeLogLock = true;
+
     PreparedStatement stmt = mock(PreparedStatement.class);
     ResultSet rs = intResult(1);
     when(stmt.executeQuery()).thenReturn(rs);
@@ -101,6 +103,8 @@ public class MySQLLockServiceTest {
   @Test
   @SuppressWarnings("resource")
   public void releaseFailure() throws Exception {
+    lockService.hasChangeLogLock = true;
+
     PreparedStatement stmt = mock(PreparedStatement.class);
     ResultSet rs = intResult(0);
     when(stmt.executeQuery()).thenReturn(rs);

--- a/src/test/java/com/github/blagerweij/sessionlock/OracleLockServiceTest.java
+++ b/src/test/java/com/github/blagerweij/sessionlock/OracleLockServiceTest.java
@@ -112,6 +112,7 @@ public class OracleLockServiceTest {
   @Test
   @SuppressWarnings("resource")
   public void releaseSuccess() throws Exception {
+    lockService.hasChangeLogLock = true;
     mockAllocateLock(dbCon);
 
     CallableStatement stmt = mock(CallableStatement.class);
@@ -130,6 +131,7 @@ public class OracleLockServiceTest {
   @Test
   @SuppressWarnings("resource")
   public void releaseFailure() throws Exception {
+    lockService.hasChangeLogLock = true;
     mockAllocateLock(dbCon);
 
     CallableStatement stmt = mock(CallableStatement.class);

--- a/src/test/java/com/github/blagerweij/sessionlock/PGLockServiceTest.java
+++ b/src/test/java/com/github/blagerweij/sessionlock/PGLockServiceTest.java
@@ -102,6 +102,8 @@ public class PGLockServiceTest {
   @Test
   @SuppressWarnings("resource")
   public void releaseSuccess() throws Exception {
+    lockService.hasChangeLogLock = true;
+
     PreparedStatement stmt = mock(PreparedStatement.class);
     ResultSet rs = booleanResult(true);
     when(stmt.executeQuery()).thenReturn(rs);
@@ -114,6 +116,8 @@ public class PGLockServiceTest {
   @Test
   @SuppressWarnings("resource")
   public void releaseFailure() throws Exception {
+    lockService.hasChangeLogLock = true;
+
     PreparedStatement stmt = mock(PreparedStatement.class);
     ResultSet rs = booleanResult(false);
     when(stmt.executeQuery()).thenReturn(rs);

--- a/src/test/java/com/github/blagerweij/sessionlock/SessionLockServiceTest.java
+++ b/src/test/java/com/github/blagerweij/sessionlock/SessionLockServiceTest.java
@@ -129,6 +129,8 @@ public class SessionLockServiceTest {
   @Test
   @SuppressWarnings("resource")
   public void releaseShouldPropagate() throws Exception {
+    lockService.hasChangeLogLock = true;
+
     SessionLockService spyService = spy(lockService);
     SQLException cause = new SQLException("baz");
     doThrow(cause).when(spyService).releaseLock(any(Connection.class));


### PR DESCRIPTION
### Problem
`SessionLockService.acquireLock()` returns true, if a lock has already been set earlier (hasChangeLogLock).

When it comes to `SessionLockService.releaseLock()` the same check for "hasChangeLogLock and return" is not applied.

Thus, when the same process requests two locks, only one lock is being created. 
Later, when the "two" locks shall be released by two subsequent calls to releaseLock, the second lock, which has never been created, cannot be released a **LockException is thrown**.  e.g. PGLockService.releaseLock#126 will throw `LockException("pg_advisory_unlock() returned " + unlocked);`

### Changes

1. This PR enhances `SessionLockService.releaseLock()` to match `SessionLockService.acquireLock()` to first check if hasChangeLogLock is true, otherwise it returns immediately similar to acquireLock.

1. SessionLockService.init() does not reset hasChangeLogLock anymore.
Because init() is called after lock has been acquired already. SessionLockService would "forget" about the lock already acquired.
Second, imho init() is not meant to reset the LockService, but for initialize tables, setup store, infrastructure. Not really needed here.

### Why this?
Happily using liquibase-sessionlock v1.5.0+ in Quarkus with success. *Thx for this*!
Recent update from Quarkus 2.14.0.Final to 2.14.1.Final disclosed this unsymmetry in liquibase-sessionlock acquireLock/releaseLock regarding hasChangeLogLock.
On [Liquibase recommendation](https://github.com/liquibase/liquibase/issues/2816#issuecomment-1297539028), Quarkus' [LiquibaseRecorder.java](https://github.com/quarkusio/quarkus/blob/main/extensions/liquibase/runtime/src/main/java/io/quarkus/liquibase/runtime/LiquibaseRecorder.java) has been [enhanced](https://github.com/quarkusio/quarkus/pull/29008) to protect/wrap liquibase.update in a lock as well. As Liquibase itself adds a lock, two consecutive locks are being set (second skipped because of hasChangeLogLock).

Quarkus' Issue: https://github.com/quarkusio/quarkus/issues/25335
