### PR TITLE
Replace usage of `@see "<a href>...</a> ..."` javadoc hack

### DIFF
--- a/src/main/java/com/github/blagerweij/sessionlock/MSSQLLockService.java
+++ b/src/main/java/com/github/blagerweij/sessionlock/MSSQLLockService.java
@@ -28,10 +28,10 @@ import java.util.Locale;
  *
  * </blockquote>
  *
- * @see "<a href='https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-getapplock-transact-sql?view=sql-server-ver15'>
- *     Application resource loking function</a> (Microsoft SQL documentation)"
- * @see "<a href='https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-releaseapplock-transact-sql?view=sql-server-ver15'>
- *     Release applicaiton resource lock function</a> (Microsoft SQL documentation)"
+ * @see <a href="https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-getapplock-transact-sql?view=sql-server-ver15"
+ *    >Application resource locking function</a> <i>(Microsoft SQL documentation)</i>
+ * @see <a href="https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-releaseapplock-transact-sql?view=sql-server-ver15"
+ *    >Release applicaiton resource lock function</a> <i>(Microsoft SQL documentation)</i>
  */
 public class MSSQLLockService extends SessionLockService {
 
@@ -80,8 +80,8 @@ public class MSSQLLockService extends SessionLockService {
    * -3   - The lock request was chosen as a deadlock victim.
    * -999 - Indicates a parameter validation or other call error.
    * In current implementation exception will be thrown only with null and -999 code values.
-   * @see "<a href='https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-getapplock-transact-sql?view=sql-server-ver15'>
-   *          Application resource loking function</a> (Microsoft SQL documentation)"
+   * @see <a href="https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-getapplock-transact-sql?view=sql-server-ver15"
+   *    >Application resource locking function</a> <i>(Microsoft SQL documentation)</i>
    */
   @Override
   protected boolean acquireLock(final Connection con) throws SQLException, LockException {
@@ -106,8 +106,8 @@ public class MSSQLLockService extends SessionLockService {
    * Return code values for <code>sp_getapplock()</code>
    * 0    - Lock was successfully released.
    * -999 - Indicates parameter validation or other call error.
-   * @see "<a href='https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-releaseapplock-transact-sql?view=sql-server-ver15'>
-   *     Release applicaiton resource lock function</a> (Microsoft SQL documentation)"
+   * @see <a href="https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-releaseapplock-transact-sql?view=sql-server-ver15"
+   *    >Release applicaiton resource lock function</a> <i>(Microsoft SQL documentation)</i>
    */
   @Override
   protected void releaseLock(final Connection con) throws SQLException, LockException {
@@ -125,11 +125,10 @@ public class MSSQLLockService extends SessionLockService {
   /**
    * Obtains information about the database changelog lock.
    *
-   * @see "<a
-   *     href='https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-tran-locks-transact-sql?view=sql-server-ver15'>
-   *     The sys.dm_tran_locks table</a> (Microsoft SQL documentation)"
-   * @see "<a href='https://docs.microsoft.com/en-us/sql/relational-databases/system-compatibility-views/sys-sysprocesses-transact-sql?view=sql-server-ver15'>
-   *     The sys.sysprocesses table</a> (Microsoft SQL documentation)"
+   * @see <a href="https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-tran-locks-transact-sql?view=sql-server-ver15"
+   *    >The sys.dm_tran_locks table</a> <i>(Microsoft SQL documentation)</i>
+   * @see <a href="https://docs.microsoft.com/en-us/sql/relational-databases/system-compatibility-views/sys-sysprocesses-transact-sql?view=sql-server-ver15"
+   *    >The sys.sysprocesses table</a> <i>(Microsoft SQL documentation)</i>
    */
   @Override
   protected DatabaseChangeLogLock usedLock(final Connection con) throws SQLException, LockException {

--- a/src/main/java/com/github/blagerweij/sessionlock/MySQLLockService.java
+++ b/src/main/java/com/github/blagerweij/sessionlock/MySQLLockService.java
@@ -27,10 +27,10 @@ import liquibase.lockservice.DatabaseChangeLogLock;
  *
  * </blockquote>
  *
- * @see "<a href='https://dev.mysql.com/doc/refman/5.7/en/locking-functions.html'>Locking
- *     Functions</a> (MySQL 5.7 Reference Manual)"
- * @see "<a href='https://dev.mysql.com/doc/refman/8.0/en/locking-functions.html'>Locking
- *     Functions</a> (MySQL 8.0 Reference Manual)"
+ * @see <a href="https://dev.mysql.com/doc/refman/5.7/en/locking-functions.html"
+ *      >Locking Functions</a> <i>(MySQL 5.7 Reference Manual)</i>
+ * @see <a href="https://dev.mysql.com/doc/refman/8.0/en/locking-functions.html"
+ *      >Locking Functions</a> <i>(MySQL 8.0 Reference Manual)</i>
  */
 public class MySQLLockService extends SessionLockService {
 
@@ -62,9 +62,8 @@ public class MySQLLockService extends SessionLockService {
   }
 
   /**
-   * @see "<a
-   *     href='https://dev.mysql.com/doc/refman/5.7/en/locking-functions.html#function_get-lock'>
-   *     <code>GET_LOCK</code></a> (Locking Functions)"
+   * @see <a href="https://dev.mysql.com/doc/refman/5.7/en/locking-functions.html#function_get-lock"
+   *    ><code>GET_LOCK</code></a> <i>(Locking Functions)</i>
    */
   @Override
   protected boolean acquireLock(Connection con) throws SQLException, LockException {
@@ -86,9 +85,8 @@ public class MySQLLockService extends SessionLockService {
   }
 
   /**
-   * @see "<a
-   *     href='https://dev.mysql.com/doc/refman/5.7/en/locking-functions.html#function_release-lock'>
-   *     <code>RELEASE_LOCK</code></a> (Locking Functions)"
+   * @see <a href="https://dev.mysql.com/doc/refman/5.7/en/locking-functions.html#function_release-lock"
+   *    ><code>RELEASE_LOCK</code></a> <i>(Locking Functions)</i>
    */
   @Override
   protected void releaseLock(Connection con) throws SQLException, LockException {
@@ -106,11 +104,10 @@ public class MySQLLockService extends SessionLockService {
   /**
    * Obtains information about the database changelog lock.
    *
-   * @see "<a
-   *     href='https://dev.mysql.com/doc/refman/5.7/en/locking-functions.html#function_is-used-lock'>
-   *     <code>IS_USED_LOCK</code></a> (Locking Functions)"
-   * @see "<a href='https://dev.mysql.com/doc/refman/5.7/en/processlist-table.html'>The
-   *     INFORMATION_SCHEMA PROCESSLIST Table</a> (MySQL Reference Manual)"
+   * @see <a href="https://dev.mysql.com/doc/refman/5.7/en/locking-functions.html#function_is-used-lock"
+   *    ><code>IS_USED_LOCK</code></a> <i>(Locking Functions)</i>
+   * @see <a href="https://dev.mysql.com/doc/refman/5.7/en/processlist-table.html"
+   *    >The INFORMATION_SCHEMA PROCESSLIST Table</a> <i>(MySQL Reference Manual)</i>
    */
   @Override
   protected DatabaseChangeLogLock usedLock(Connection con) throws SQLException, LockException {

--- a/src/main/java/com/github/blagerweij/sessionlock/OracleLockService.java
+++ b/src/main/java/com/github/blagerweij/sessionlock/OracleLockService.java
@@ -21,9 +21,8 @@ import liquibase.lockservice.DatabaseChangeLogLock;
  *
  * <p>See {@link MySQLLockService} for a very similar implementation.
  *
- * @see "<a
- *     href='https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_LOCK.html'>
- *     <code>DBMS_LOCK</code> Package</a> (Oracle PL/SQL Reference Manual)"
+ * @see <a href="https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_LOCK.html"
+ *    ><code>DBMS_LOCK</code> Package</a> <i>(Oracle PL/SQL Reference Manual)</i>
  */
 public class OracleLockService extends SessionLockService {
 
@@ -46,9 +45,8 @@ public class OracleLockService extends SessionLockService {
   }
 
   /**
-   * @see "<a
-   *     href='https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_LOCK.html#GUID-73F03FA6-04B3-4341-AB4F-8BECCF898D13'>
-   *     <code>DBMS_LOCK.ALLOCATE_UNIQUE</code> Procedure</a> (Oracle PL/SQL Reference Manual)"
+   * @see <a href="https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_LOCK.html#GUID-73F03FA6-04B3-4341-AB4F-8BECCF898D13"
+   *    ><code>DBMS_LOCK.ALLOCATE_UNIQUE</code> Procedure</a> <i>(Oracle PL/SQL Reference Manual)</i>
    */
   private String allocateLock(Connection con) throws SQLException {
     // Allocate lock
@@ -62,9 +60,8 @@ public class OracleLockService extends SessionLockService {
   }
 
   /**
-   * @see "<a
-   *     href='https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_LOCK.html#GUID-CC3AEC00-CBFF-45DD-99C3-C7A312C0213E'>
-   *     <code>DBMS_LOCK.REQUEST</code> Procedure</a> (Oracle PL/SQL Reference Manual)"
+   * @see <a href="https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_LOCK.html#GUID-CC3AEC00-CBFF-45DD-99C3-C7A312C0213E"
+   *    ><code>DBMS_LOCK.REQUEST</code> Procedure</a> <i>(Oracle PL/SQL Reference Manual)</i>
    */
   @Override
   protected boolean acquireLock(Connection con) throws SQLException, LockException {
@@ -98,9 +95,8 @@ public class OracleLockService extends SessionLockService {
   }
 
   /**
-   * @see "<a
-   *     href='https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_LOCK.html#GUID-1007B402-15D3-4447-9FF3-219DF113A47B'>
-   *     <code>DBMS_LOCK.RELEASE</code> Procedure</a> (Oracle PL/SQL Reference Manual)"
+   * @see <a href="https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_LOCK.html#GUID-1007B402-15D3-4447-9FF3-219DF113A47B"
+   *    ><code>DBMS_LOCK.RELEASE</code> Procedure</a> <i>(Oracle PL/SQL Reference Manual)</i>
    */
   @Override
   protected void releaseLock(Connection con) throws SQLException, LockException {
@@ -140,12 +136,10 @@ public class OracleLockService extends SessionLockService {
    * AND LOCKS_ALLOCATED.NAME = 'lockName';
    * </code></pre>
    *
-   * @see "<a
-   *     href='https://docs.oracle.com/en/database/oracle/oracle-database/19/refrn/DBMS_LOCK_ALLOCATED.html'>The
-   *     DBMS_LOCK_ALLOCATED Table</a> (Oracle PL/SQL Reference Manual)"
-   * @see "<a
-   *     href='https://docs.oracle.com/en/database/oracle/oracle-database/19/refrn/DBA_LOCK.html'>The
-   *     DBA_LOCK View</a> (Oracle PL/SQL Reference Manual)"
+   * @see <a href="https://docs.oracle.com/en/database/oracle/oracle-database/19/refrn/DBMS_LOCK_ALLOCATED.html"
+   *    >The DBMS_LOCK_ALLOCATED Table</a> <i>(Oracle PL/SQL Reference Manual)</i>
+   * @see <a href="https://docs.oracle.com/en/database/oracle/oracle-database/19/refrn/DBA_LOCK.html"
+   *    >The DBA_LOCK View</a> <i>(Oracle PL/SQL Reference Manual)</i>
    */
   @Override
   protected DatabaseChangeLogLock usedLock(Connection con) throws SQLException {

--- a/src/main/java/com/github/blagerweij/sessionlock/PGLockService.java
+++ b/src/main/java/com/github/blagerweij/sessionlock/PGLockService.java
@@ -32,8 +32,8 @@ import liquibase.lockservice.DatabaseChangeLogLock;
  *
  * </blockquote>
  *
- * @see "<a href='https://www.postgresql.org/docs/9.6/explicit-locking.html#ADVISORY-LOCKS'>Advisory
- *     Locks</a> (PostgreSQL Documentation)"
+ * @see <a href="https://www.postgresql.org/docs/9.6/explicit-locking.html#ADVISORY-LOCKS"
+ *      >Advisory Locks</a> <i>(PostgreSQL Documentation)</i>
  */
 public class PGLockService extends SessionLockService {
 
@@ -89,9 +89,8 @@ public class PGLockService extends SessionLockService {
   }
 
   /**
-   * @see "<a
-   *     href='https://www.postgresql.org/docs/9.6/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS'>
-   *     <code>pg_try_advisory_lock</code></a> (Advisory Lock Functions)"
+   * @see <a href="https://www.postgresql.org/docs/9.6/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS"
+   *    ><code>pg_try_advisory_lock</code></a> <i>(Advisory Lock Functions)</i>
    */
   @Override
   protected boolean acquireLock(Connection con) throws SQLException, LockException {
@@ -105,9 +104,8 @@ public class PGLockService extends SessionLockService {
   }
 
   /**
-   * @see "<a
-   *     href='https://www.postgresql.org/docs/9.6/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS'>
-   *     <code>pg_advisory_unlock</code></a> (Advisory Lock Functions)"
+   * @see <a href="https://www.postgresql.org/docs/9.6/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS"
+   *    ><code>pg_advisory_unlock</code></a> <i>(Advisory Lock Functions)</i>
    */
   @Override
   protected void releaseLock(Connection con) throws SQLException, LockException {
@@ -133,11 +131,10 @@ public class PGLockService extends SessionLockService {
    *
    * </blockquote>
    *
-   * @see "<a href='https://www.postgresql.org/docs/9.6/view-pg-locks.html'><code>pg_locks</code>
-   *     </a> (PostgreSQL Documentation)"
-   * @see "<a
-   *     href='https://www.postgresql.org/docs/9.6/monitoring-stats.html#PG-STAT-ACTIVITY-VIEW'>
-   *     <code>pg_stat_activity</code> View</a> (PostgreSQL Documentation)"
+   * @see <a href="https://www.postgresql.org/docs/9.6/view-pg-locks.html"
+   *    ><code>pg_locks</code></a> <i>(PostgreSQL Documentation)</i>
+   * @see <a href="https://www.postgresql.org/docs/9.6/monitoring-stats.html#PG-STAT-ACTIVITY-VIEW"
+   *    ><code>pg_stat_activity</code> View</a> <i>(PostgreSQL Documentation)</i>
    */
   @Override
   protected DatabaseChangeLogLock usedLock(Connection con) throws SQLException, LockException {


### PR DESCRIPTION
If you build using a newer Gradle version supporting Java 17+:

```
gradle javadoc
```

you may notice (`build/docs/javadoc/`) the content of `@see "<a href>...</a> ..."` references is rendered as literal text:

>   "\<a href="https\://dev.mysql.com/doc/refman/8.0/en/locking-functions.html">Locking Functions</a> (MySQL 8.0 Reference Manual)"

vs. raw HTML markup:

>   "[Locking Functions](https://dev.mysql.com/doc/refman/8.0/en/locking-functions.html) (MySQL 8.0 Reference Manual)"

I remember using this hack previously for the purpose of including [`cite`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite) HTML markup (providing extra context where the original link was found):

```
@see  "<a href>...</a> <cite>...</cite>"
```

because `cite` is not recognized by javadoc ([JDK-4907024]).  Since then I've also dropped the usage of `cite`, and that could be replaced by a generic typography markup – `i` (italics):

```
@see  <a href>...</a> <i>...</i>
```

See also:

-   [@see](https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html#see), _Documentation Comment Specification for the Standard Doclet (JDK 17)_

[JDK-4907024]: https://bugs.openjdk.org/browse/JDK-4907024 "spurious warning if use html tag <cite> as part of an @see line"