### PR TITLE
Use catalogName instead of schemaName to determine lock name for Oracle

### DIFF
--- a/src/main/java/com/github/blagerweij/sessionlock/OracleLockService.java
+++ b/src/main/java/com/github/blagerweij/sessionlock/OracleLockService.java
@@ -40,7 +40,7 @@ public class OracleLockService extends SessionLockService {
   }
 
   private String getChangeLogLockName() {
-    return (database.getLiquibaseSchemaName() + "." + database.getDatabaseChangeLogLockTableName())
+    return (database.getLiquibaseCatalogName() + "." + database.getDatabaseChangeLogLockTableName())
         .toUpperCase(Locale.ROOT);
   }
 


### PR DESCRIPTION
The OracleDatabase does not support setting the schemaName. See: https://github.com/liquibase/liquibase/blob/master/liquibase-standard/src/main/java/liquibase/database/core/OracleDatabase.java#L291

E.g. with Spring integration the `spring.liquibase.liquibase-schema` property is ignored when used against an Oracle database.