### PR TITLE
use BigInt for session lock/unlock to be compatible with CockroachDB

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.6.5
+version=1.6.5-COCKROACH
 systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false
 systemProp.org.gradle.internal.http.connectionTimeout=200000
 systemProp.org.gradle.internal.http.socketTimeout=200000


### PR DESCRIPTION
TODO: need to change the version back

This PR changes the session lock to use the `BigInt` acquire/release methods rather than the `int, int` methods.
I've tested it with integration tests on a repo - unfortunately private and I can't share here, but the results work.
It works well with both Postgres and CockroachDB vendors now.

Are you interested in bringing in this change?  If so I could try to bring it in line with the code & tests you have, otherwise I will retain a separate fork for now.

This covers issues https://github.com/blagerweij/liquibase-sessionlock/issues/32

EDIT: in case you don't know much about CockroachDB, it's more of an online version of Postgres (with restrictions) and you can use the Postgres JDBC driver.
