### PR TITLE
Drop confusing Public Domain disclaimer from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,5 @@ implementation("com.github.blagerweij:liquibase-sessionlock:1.6.7")
 ```
 </details>
 
-## Disclaimer
-
-_This module, both source code and documentation, is in the Public Domain, and comes with **NO WARRANTY**._
-
 ## License
 This module is using the Apache Software License, version 2.0. See http://www.apache.org/licenses/LICENSE-2.0.txt


### PR DESCRIPTION
`liquibase-sessionlock` uses the [Apache License v2](/blagerweij/liquibase-sessionlock/blob/83651f7c05065cce16386a307376c6adec26edf3/LICENSE).  The Public Domain disclaimer is a remnant of my initial work and is likely confusing.  It is at least to me.

This change doesn't deserve a new release, and I'm unsure how to avoid triggering the CI.  I see there are commits tagged `[skip ci]` – should this be included in the subject, or could go at the end of the commit message body?  I guess you could add that on merge ("Squash and merge"), also.